### PR TITLE
Rest of Android support

### DIFF
--- a/eng/Subsets.props
+++ b/eng/Subsets.props
@@ -51,7 +51,7 @@
 
   <PropertyGroup>
     <!-- CLR NativeAot only builds in a subset of the matrix -->
-    <NativeAotSupported Condition="('$(TargetOS)' == 'windows' or '$(TargetOS)' == 'linux' or '$(TargetOS)' == 'OSX') and ('$(TargetArchitecture)' == 'x64' or '$(TargetArchitecture)' == 'arm64') and ('$(TargetOS)' != 'OSX' or '$(TargetArchitecture)' != 'arm64') and ('$(__DistroRid)' != 'linux-musl-arm64')">true</NativeAotSupported>
+    <NativeAotSupported Condition="('$(TargetOS)' == 'windows' or '$(TargetOS)' == 'linux' or '$(TargetOS)' == 'OSX' or '$(TargetOS)' == 'Android') and ('$(TargetArchitecture)' == 'x64' or '$(TargetArchitecture)' == 'arm64') and ('$(TargetOS)' != 'OSX' or '$(TargetArchitecture)' != 'arm64') and ('$(__DistroRid)' != 'linux-musl-arm64')">true</NativeAotSupported>
 
     <!-- If we're building clr.nativeaotlibs and not building the CLR runtime, compile libraries against NativeAOT CoreLib -->
     <UseNativeAotCoreLib Condition="$(_subset.Contains('+clr.nativeaotlibs+')) and !$(_subset.Contains('+clr+')) and !$(_subset.Contains('+clr.runtime+'))">true</UseNativeAotCoreLib>

--- a/eng/native/build-commons.sh
+++ b/eng/native/build-commons.sh
@@ -102,6 +102,8 @@ build_native()
             echo "Error: Unknown Android architecture $platformArch."
             exit 1
         fi
+
+        cmakeArgs="-C $__RepoRootDir/eng/native/tryrun.cmake $cmakeArgs"
     fi
 
     if [[ "$__UseNinja" == 1 ]]; then

--- a/src/coreclr/CMakeLists.txt
+++ b/src/coreclr/CMakeLists.txt
@@ -66,11 +66,11 @@ include(components.cmake)
 #---------------------------
 # Build the single file host
 #---------------------------
-if(NOT CLR_CROSS_COMPONENTS_BUILD)
-  set(CLR_SINGLE_FILE_HOST_ONLY 1)
-  add_subdirectory(${CLR_SRC_NATIVE_DIR}/corehost/apphost/static Corehost.Static)
-  add_dependencies(runtime singlefilehost)
-endif()
+#if(NOT CLR_CROSS_COMPONENTS_BUILD)
+#  set(CLR_SINGLE_FILE_HOST_ONLY 1)
+#  add_subdirectory(${CLR_SRC_NATIVE_DIR}/corehost/apphost/static Corehost.Static)
+#  add_dependencies(runtime singlefilehost)
+#endif()
 #-------------------------
 # Enable C++ EH with SEH
 #-------------------------
@@ -93,17 +93,17 @@ endif(NOT CLR_CROSS_COMPONENTS_BUILD)
 #     - do not depend on clr's compile definitions
 #-----------------------------------------
 if(CLR_CMAKE_HOST_UNIX)
-    if(CLR_CMAKE_TARGET_ANDROID)
-        find_library(LZMA NAMES lzma)
-        if(LZMA STREQUAL LZMA-NOTFOUND)
-           message(FATAL_ERROR "Cannot find liblzma.")
-        endif(LZMA STREQUAL LZMA-NOTFOUND)
+#    if(CLR_CMAKE_TARGET_ANDROID)
+#        find_library(LZMA NAMES lzma)
+#        if(LZMA STREQUAL LZMA-NOTFOUND)
+#           message(FATAL_ERROR "Cannot find liblzma.")
+#        endif(LZMA STREQUAL LZMA-NOTFOUND)
 
-        find_library(ANDROID_GLOB NAMES android-glob)
-        if(ANDROID_GLOB STREQUAL ANDROID_GLOB-NOTFOUND)
-          message(FATAL_ERROR "Cannot find android-glob.")
-        endif()
-    endif()
+#        find_library(ANDROID_GLOB NAMES android-glob)
+#        if(ANDROID_GLOB STREQUAL ANDROID_GLOB-NOTFOUND)
+#          message(FATAL_ERROR "Cannot find android-glob.")
+#        endif()
+#    endif()
 
     add_subdirectory(pal)
     add_subdirectory(hosts)

--- a/src/coreclr/Directory.Build.props
+++ b/src/coreclr/Directory.Build.props
@@ -8,6 +8,9 @@
     <Configuration Condition="'$(Configuration)' == 'release'">Release</Configuration>
     <Configuration Condition="'$(Configuration)' == 'checked'">Checked</Configuration>
 
+    <!-- Version of the Android SDK we target, keep in sync with src/libraries/Native/build-native.sh -->
+    <AndroidApiVersion>21</AndroidApiVersion>
+
     <UseMonoRuntime>false</UseMonoRuntime>
   </PropertyGroup>
 

--- a/src/coreclr/runtime.proj
+++ b/src/coreclr/runtime.proj
@@ -50,6 +50,22 @@
       <_CoreClrBuildArg Condition="'$(ClrNativeAotSubset)' == 'true'" Include="-component nativeaot" />
     </ItemGroup>
 
+   <ItemGroup Condition="'$(TargetsAndroid)' == 'true'">
+      <_CoreClrBuildArg Include="-cmakeargs -DCMAKE_TOOLCHAIN_FILE=$(ANDROID_NDK_ROOT)/build/cmake/android.toolchain.cmake"/>
+      <_CoreClrBuildArg Include="-cmakeargs -DANDROID_NDK=$(ANDROID_NDK_ROOT)"/>
+      <_CoreClrBuildArg Include="-cmakeargs -DANDROID_STL=c++_static"/>
+      <_CoreClrBuildArg Include="-cmakeargs -DANDROID_CPP_FEATURES=&quot;no-rtti no-exceptions&quot;"/>
+      <_CoreClrBuildArg Include="-cmakeargs -DANDROID_NATIVE_API_LEVEL=$(AndroidApiVersion)"/>
+      <_CoreClrBuildArg Include="-cmakeargs -DANDROID_PLATFORM=android-$(AndroidApiVersion)"/>
+      <_CoreClrBuildArg Condition="'$(Platform)' == 'arm64'" Include="-cmakeargs -DANDROID_ABI=arm64-v8a" />
+      <_CoreClrBuildArg Condition="'$(Platform)' == 'arm'" Include="-cmakeargs -DANDROID_ABI=armeabi-v7a" />
+      <_CoreClrBuildArg Condition="'$(Platform)' == 'x86'" Include="-cmakeargs -DANDROID_ABI=x86" />
+      <_CoreClrBuildArg Condition="'$(Platform)' == 'x64'" Include="-cmakeargs -DANDROID_ABI=x86_64" />
+
+      <!-- No LTTNG on Android -->
+      <_CoreClrBuildArg Include="-cmakeargs -DFEATURE_EVENT_TRACE=0"/>
+    </ItemGroup>
+
     <PropertyGroup>
       <_CoreClrBuildScript Condition="$([MSBuild]::IsOsPlatform(Windows))">build-runtime.cmd</_CoreClrBuildScript>
       <_CoreClrBuildScript Condition="!$([MSBuild]::IsOsPlatform(Windows))">build-runtime.sh</_CoreClrBuildScript>


### PR DESCRIPTION
Get Android NDK and set up environment variables that the build needs:

```
export NDK_VER=r21b
export ANDROID_NDK_ROOT=~/android-ndk-${NDK_VER}
export HOST_OS=linux
curl https://dl.google.com/android/repository/android-ndk-${NDK_VER}-${HOST_OS}-x86_64.zip -L --output ~/andk.zip
```

Build libs with this patch:

```
TARGET_BUILD_ARCH=arm64 ./build.sh -s clr.nativeaotlibs+libs -arch arm64 -os Android
```

We need the TARGET_BUILD_ARCH hack line because this variable is only set for crossbuilds and the infra doesn't consider Android a crossbuild.

Now you have framework libs in artifacts\bin\microsoft.netcore.app.runtime.android-arm64\Debug\runtimes\android-arm64 (managed and native) and NativeAOT libs in artifacts\bin\coreclr\Android.arm64.Debug\aotsdk.

Use ILC as if you're compiling for ARM64 Linux but point it to the libs that came out of the Android build above.

Once you have an object file, link it with the native libs that came out of the Android build of clr.nativeaotlibs+libs above:

android-ndk-r21b\toolchains\llvm\prebuilt\windows-x86_64\bin\aarch64-linux-android28-clang.cmd c:\android\repro.o -lm -lstdc++ C:\android\aotsdk\libbootstrapper.a C:\android\aotsdk\libRuntime.WorkstationGC.a c:\android\native\libSystem.Native.a -o c:\android\repro

To run on a phone:

Get e.g. Termiux.

Make sure Termiux has access to the storage:

```
termux-setup-storage
```

Copy over to a location that allows execution (~/storage does not):

```
cp ~/storage/csharpdebuginfo ~/csharpdebuginfo
chmod +x csharpdebuginfo
~/csharpdebuginfo
```

You might also need to copy over libc++_shared.so from the Android NDK. I also had to LD_PRELOAD it.